### PR TITLE
Set low cache control

### DIFF
--- a/update/s3.go
+++ b/update/s3.go
@@ -167,7 +167,9 @@ func WriteHTML(bucketName string, prefixes string, suffix string, outPath string
 		}
 		bucket = client.s3.Bucket(bucketName)
 		log.Printf("Uploading to %s", urlStringNoEscape(bucketName, uploadDest))
-		err = bucket.Put(uploadDest, buf.Bytes(), "text/html", s3.PublicRead, s3.Options{})
+		opts := s3.Options{}
+		opts.CacheControl = "maxage=60"
+		err = bucket.Put(uploadDest, buf.Bytes(), "text/html", s3.PublicRead, opts)
 		if err != nil {
 			return err
 		}
@@ -310,7 +312,9 @@ func (c *Client) CopyLatest(bucketName string, platform string) error {
 		}
 		bucket := c.s3.Bucket(bucketName)
 		log.Printf("PutCopying %s to %s\n", url, platform.LatestName)
-		_, err = bucket.PutCopy(platform.LatestName, s3.PublicRead, s3.CopyOptions{}, url)
+		opts := s3.CopyOptions{}
+		opts.CacheControl = "maxage=60"
+		_, err = bucket.PutCopy(platform.LatestName, s3.PublicRead, opts, url)
 		if err != nil {
 			return err
 		}
@@ -432,7 +436,9 @@ func (c *Client) PromoteRelease(bucketName string, delay time.Duration, beforeHo
 	jsonName := updateJSONName(channel, platform.Name, env)
 	jsonURL := urlString(bucketName, platform.PrefixSupport, fmt.Sprintf("update-%s-%s-%s.json", platform.Name, env, release.Version))
 	log.Printf("PutCopying %s to %s\n", jsonURL, jsonName)
-	_, err = bucket.PutCopy(jsonName, s3.PublicRead, s3.CopyOptions{}, jsonURL)
+	opts := s3.CopyOptions{}
+	opts.CacheControl = "maxage=60"
+	_, err = bucket.PutCopy(jsonName, s3.PublicRead, opts, jsonURL)
 	if err != nil {
 		return nil, err
 	}
@@ -448,7 +454,9 @@ func copyUpdateJSON(bucketName string, channel string, platformName string, env 
 	jsonURLSource := urlString(bucketName, "", updateJSONName("", platformName, env))
 	bucket := client.s3.Bucket(bucketName)
 	log.Printf("PutCopying %s to %s\n", jsonURLSource, jsonNameDest)
-	_, err = bucket.PutCopy(jsonNameDest, s3.PublicRead, s3.CopyOptions{}, jsonURLSource)
+	opts := s3.CopyOptions{}
+	opts.CacheControl = "maxage=60"
+	_, err = bucket.PutCopy(jsonNameDest, s3.PublicRead, opts, jsonURLSource)
 	return err
 }
 


### PR DESCRIPTION
Use a low cache control setting for html files and latest package files when copying to s3.

This doesn't affect immutable files.

@maxtaco 