### PR TITLE
Allow promoting a specific build to public

### DIFF
--- a/release.go
+++ b/release.go
@@ -81,6 +81,11 @@ var (
 	promoteReleasesBucketName = promoteReleasesCmd.Flag("bucket-name", "Bucket name to use").Required().String()
 	promoteReleasesPlatform   = promoteReleasesCmd.Flag("platform", "Platform (darwin, linux, windows)").Required().String()
 
+	promoteAReleaseCmd        = app.Command("promote-a-release", "Promote a specific release")
+	releaseToPromote          = promoteAReleaseCmd.Flag("release", "Specific release to promote to public").Required().String()
+	promoteAReleaseBucketName = promoteAReleaseCmd.Flag("bucket-name", "Bucket name to use").Required().String()
+	promoteAReleasePlatform   = promoteAReleaseCmd.Flag("platform", "Platform (darwin, linux, windows)").Required().String()
+
 	promoteTestReleasesCmd        = app.Command("promote-test-releases", "Promote test releases")
 	promoteTestReleasesBucketName = promoteTestReleasesCmd.Flag("bucket-name", "Bucket name to use").Required().String()
 	promoteTestReleasesPlatform   = promoteTestReleasesCmd.Flag("platform", "Platform (darwin, linux, windows)").Required().String()
@@ -163,6 +168,11 @@ func main() {
 		log.Printf("%s\n", commit)
 	case promoteReleasesCmd.FullCommand():
 		err := update.PromoteReleases(*promoteReleasesBucketName, *promoteReleasesPlatform)
+		if err != nil {
+			log.Fatal(err)
+		}
+	case promoteAReleaseCmd.FullCommand():
+		err := update.PromoteARelease(*releaseToPromote, *promoteAReleaseBucketName, *promoteAReleasePlatform)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/update/s3.go
+++ b/update/s3.go
@@ -401,7 +401,6 @@ func (c *Client) promoteDarwinReleaseToProd(releaseName string, bucketName strin
 	bucket := c.s3.Bucket(bucketName)
 	releaseName = fmt.Sprintf("Keybase-%s.dmg", releaseName)
 	release, err := platform.FindRelease(*bucket, func(r Release) bool {
-		log.Printf("Checking release name %s against %s", r.Name, releaseName)
 		if r.Name == releaseName {
 			return true
 		}

--- a/update/s3.go
+++ b/update/s3.go
@@ -420,7 +420,7 @@ func (c *Client) promoteDarwinReleaseToProd(releaseName string, bucketName strin
 	log.Printf("PutCopying %s to %s\n", jsonURL, jsonName)
 	opts := s3.CopyOptions{}
 	opts.CacheControl = "maxage=60"
-	//_, err = bucket.PutCopy(jsonName, s3.PublicRead, opts, jsonURL)
+	_, err = bucket.PutCopy(jsonName, s3.PublicRead, opts, jsonURL)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
@gabriel @oconnor663 

Here's the terminal output (untested with the final copy command NOPd).  The idea is to call this from Slackbot; that's keybase/slackbot#8.
```
 λ ./release promote-a-release --release 1.0.15-20160404130015+8ac9934 --bucket-name prerelease.keybase.io --platform darwin
2016/04/07 12:21:30 Checking release name Keybase-1.0.15-20160407130013+32baba2.dmg against Keybase-1.0.15-20160404130015+8ac9934.dmg
2016/04/07 12:21:30 Checking release name Keybase-1.0.15-20160406130015+05efae8.dmg against Keybase-1.0.15-20160404130015+8ac9934.dmg
2016/04/07 12:21:30 Checking release name Keybase-1.0.15-20160405190013+c3c738d.dmg against Keybase-1.0.15-20160404130015+8ac9934.dmg
2016/04/07 12:21:30 Checking release name Keybase-1.0.15-20160405175206+c3c738d.dmg against Keybase-1.0.15-20160404130015+8ac9934.dmg
2016/04/07 12:21:30 Checking release name Keybase-1.0.15-20160404190011+0112799.dmg against Keybase-1.0.15-20160404130015+8ac9934.dmg
2016/04/07 12:21:30 Checking release name Keybase-1.0.15-20160404130015+8ac9934.dmg against Keybase-1.0.15-20160404130015+8ac9934.dmg
2016/04/07 12:21:30 Found release Keybase-1.0.15-20160404130015+8ac9934.dmg (75h21m15.618702577s), 1.0.15-20160404130015+8ac9934
2016/04/07 12:21:30 PutCopying https://s3.amazonaws.com/prerelease.keybase.io/darwin-support/update-darwin-prod-1.0.15-20160404130015%2B8ac9934.json to update-darwin-prod.json
2016/04/07 12:21:30 Promoted (darwin) release: Keybase-1.0.15-20160404130015+8ac9934.dmg
```