### PR TITLE
Release: support updater smoketesting commands

### DIFF
--- a/release.go
+++ b/release.go
@@ -24,6 +24,14 @@ func githubToken(required bool) string {
 	return token
 }
 
+func keybaseToken(required bool) string {
+	token := os.Getenv("KEYBASE_TOKEN")
+	if token == "" && required {
+		log.Fatal("No KEYBASE_TOKEN set")
+	}
+	return token
+}
+
 func tag(version string) string {
 	return fmt.Sprintf("v%s", version)
 }
@@ -243,12 +251,12 @@ func main() {
 			log.Fatal(err)
 		}
 	case announceNewBuildCmd.FullCommand():
-		err := update.AnnounceNewBuild(*announceNewBuildA, *announceNewBuildB, *announceNewBuildPlatform)
+		err := update.AnnounceNewBuild(keybaseToken(true), *announceNewBuildA, *announceNewBuildB, *announceNewBuildPlatform)
 		if err != nil {
 			log.Fatal(err)
 		}
 	case setBuildInTestingCmd.FullCommand():
-		err := update.SetBuildInTesting(*setBuildInTestingA, *setBuildInTestingPlatform, *setBuildInTestingEnable)
+		err := update.SetBuildInTesting(keybaseToken(true), *setBuildInTestingA, *setBuildInTestingPlatform, *setBuildInTestingEnable)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/release.go
+++ b/release.go
@@ -109,6 +109,11 @@ var (
 	waitForCIContexts = waitForCICmd.Flag("context", "Context to check for success").Required().Strings()
 	waitForCIDelay    = waitForCICmd.Flag("delay", "Delay between checks").Default("1m").Duration()
 	waitForCITimeout  = waitForCICmd.Flag("timeout", "Delay between checks").Default("1h").Duration()
+
+	announceNewBuildCmd      = app.Command("announce-new-build-to-server", "Inform the API server of the existence of a new build")
+	announceNewBuildA        = announceNewBuildCmd.Flag("build-a", "The first of the two IDs comprising the new build").Required().String()
+	announceNewBuildB        = announceNewBuildCmd.Flag("build-b", "The first of the two IDs comprising the new build").Required().String()
+	announceNewBuildPlatform = announceNewBuildCmd.Flag("platform", "Platform (darwin, linux, windows)").Required().String()
 )
 
 func main() {
@@ -229,6 +234,11 @@ func main() {
 		fmt.Printf("%s", commit.SHA)
 	case waitForCICmd.FullCommand():
 		err := gh.WaitForCI(githubToken(true), *waitForCIRepo, *waitForCICommit, *waitForCIContexts, *waitForCIDelay, *waitForCITimeout)
+		if err != nil {
+			log.Fatal(err)
+		}
+	case announceNewBuildCmd.FullCommand():
+		err := update.AnnounceNewBuild(*announceNewBuildA, *announceNewBuildB, *announceNewBuildPlatform)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/release.go
+++ b/release.go
@@ -251,7 +251,7 @@ func main() {
 			log.Fatal(err)
 		}
 	case announceBuildCmd.FullCommand():
-		err := update.AnnounceNewBuild(keybaseToken(true), *announceBuildA, *announceBuildB, *announceBuildPlatform)
+		err := update.AnnounceBuild(keybaseToken(true), *announceBuildA, *announceBuildB, *announceBuildPlatform)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/release.go
+++ b/release.go
@@ -118,10 +118,10 @@ var (
 	waitForCIDelay    = waitForCICmd.Flag("delay", "Delay between checks").Default("1m").Duration()
 	waitForCITimeout  = waitForCICmd.Flag("timeout", "Delay between checks").Default("1h").Duration()
 
-	announceNewBuildCmd      = app.Command("announce-new-build-to-server", "Inform the API server of the existence of a new build")
-	announceNewBuildA        = announceNewBuildCmd.Flag("build-a", "The first of the two IDs comprising the new build").Required().String()
-	announceNewBuildB        = announceNewBuildCmd.Flag("build-b", "The first of the two IDs comprising the new build").Required().String()
-	announceNewBuildPlatform = announceNewBuildCmd.Flag("platform", "Platform (darwin, linux, windows)").Required().String()
+	announceBuildCmd      = app.Command("announce-build", "Inform the API server of the existence of a new build")
+	announceBuildA        = announceBuildCmd.Flag("build-a", "The first of the two IDs comprising the new build").Required().String()
+	announceBuildB        = announceBuildCmd.Flag("build-b", "The first of the two IDs comprising the new build").Required().String()
+	announceBuildPlatform = announceBuildCmd.Flag("platform", "Platform (darwin, linux, windows)").Required().String()
 
 	setBuildInTestingCmd      = app.Command("set-build-in-testing", "Enroll or unenroll a build in smoketesting")
 	setBuildInTestingA        = setBuildInTestingCmd.Flag("build-a", "The first build's ID").Required().String()
@@ -250,8 +250,8 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-	case announceNewBuildCmd.FullCommand():
-		err := update.AnnounceNewBuild(keybaseToken(true), *announceNewBuildA, *announceNewBuildB, *announceNewBuildPlatform)
+	case announceBuildCmd.FullCommand():
+		err := update.AnnounceNewBuild(keybaseToken(true), *announceBuildA, *announceBuildB, *announceBuildPlatform)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/release.go
+++ b/release.go
@@ -114,6 +114,11 @@ var (
 	announceNewBuildA        = announceNewBuildCmd.Flag("build-a", "The first of the two IDs comprising the new build").Required().String()
 	announceNewBuildB        = announceNewBuildCmd.Flag("build-b", "The first of the two IDs comprising the new build").Required().String()
 	announceNewBuildPlatform = announceNewBuildCmd.Flag("platform", "Platform (darwin, linux, windows)").Required().String()
+
+	setBuildInTestingCmd      = app.Command("set-build-in-testing", "Enroll or unenroll a build in smoketesting")
+	setBuildInTestingA        = setBuildInTestingCmd.Flag("build-a", "The first build's ID").Required().String()
+	setBuildInTestingPlatform = setBuildInTestingCmd.Flag("platform", "Platform (darwin, linux, windows)").Required().String()
+	setBuildInTestingEnable   = setBuildInTestingCmd.Flag("enable", "Enroll the build in smoketesting (boolish string)").Required().String()
 )
 
 func main() {
@@ -242,5 +247,11 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+	case setBuildInTestingCmd.FullCommand():
+		err := update.SetBuildInTesting(*setBuildInTestingA, *setBuildInTestingPlatform, *setBuildInTestingEnable)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
+
 }

--- a/update/kbweb.go
+++ b/update/kbweb.go
@@ -1,0 +1,101 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package update
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+const (
+	kbwebAPIUrl = "https://api.keybase.io"
+)
+
+const apiCa = `-----BEGIN CERTIFICATE-----
+MIIGmzCCBIOgAwIBAgIJAPzhpcIBaOeNMA0GCSqGSIb3DQEBBQUAMIGPMQswCQYD
+VQQGEwJVUzELMAkGA1UECBMCTlkxETAPBgNVBAcTCE5ldyBZb3JrMRQwEgYDVQQK
+EwtLZXliYXNlIExMQzEXMBUGA1UECxMOQ2VydCBBdXRob3JpdHkxEzARBgNVBAMT
+CmtleWJhc2UuaW8xHDAaBgkqhkiG9w0BCQEWDWNhQGtleWJhc2UuaW8wHhcNMTQw
+MTAyMTY0MjMzWhcNMjMxMjMxMTY0MjMzWjCBjzELMAkGA1UEBhMCVVMxCzAJBgNV
+BAgTAk5ZMREwDwYDVQQHEwhOZXcgWW9yazEUMBIGA1UEChMLS2V5YmFzZSBMTEMx
+FzAVBgNVBAsTDkNlcnQgQXV0aG9yaXR5MRMwEQYDVQQDEwprZXliYXNlLmlvMRww
+GgYJKoZIhvcNAQkBFg1jYUBrZXliYXNlLmlvMIICIjANBgkqhkiG9w0BAQEFAAOC
+Ag8AMIICCgKCAgEA3sLA6ZG8uOvmlFvFLVIOURmcQrZyMFKbVu9/TeDiemls3w3/
+JzVTduD+7KiUi9R7QcCW/V1ZpReTfunm7rfACiJ1fpIkjSQrgsvKDLghIzxIS5FM
+I8utet5p6QtuJhaAwmmXn8xX05FvqWNbrcXRdpL4goFdigPsFK2xhTUiWatLMste
+oShI7+zmrgkx75LeLMD0bL2uOf87JjOzbY8x2sUIZLGwPoATyG8WS38ey6KkJxRj
+AhG3p+OTYEjYSrsAtQA6ImbeDpfSHKOB8HF3nVp//Eb4HEiEsWwBRbQXvAWh3DYL
+GukFW0wiO0HVCoWY+bHL/Mqa0NdRGOlLsbL4Z4pLrhqKgSDU8umX9YuNRRaB0P5n
+TkzyU6axHqzq990Gep/I62bjsBdYYp+DjSPK43mXRrfWJl2NTcl8xKAyfsOW+9hQ
+9vwK0tpSicNxfYuUZs0BhfjSZ/Tc6Z1ERdgUYRiXTtohl+SRA2IgZMloHCllVMNj
+EjXhguvHgLAOrcuyhVBupiUQGUHQvkMsr1Uz8VPNDFOJedwucRU2AaR881bknnSb
+ds9+zNLsvUFV+BK7Qdnt/WkFpYL78rGwY47msi9Ooddx6fPyeg3qkJGM6cwn/boy
+w9lQeleYDq8kyJdixIAxtAskNzRPJ4nDu2izTfByQoM8epwAWboc/gNFObMCAwEA
+AaOB9zCB9DAdBgNVHQ4EFgQURqpATOw1gVVrzlqqFKbkfaKXvwowgcQGA1UdIwSB
+vDCBuYAURqpATOw1gVVrzlqqFKbkfaKXvwqhgZWkgZIwgY8xCzAJBgNVBAYTAlVT
+MQswCQYDVQQIEwJOWTERMA8GA1UEBxMITmV3IFlvcmsxFDASBgNVBAoTC0tleWJh
+c2UgTExDMRcwFQYDVQQLEw5DZXJ0IEF1dGhvcml0eTETMBEGA1UEAxMKa2V5YmFz
+ZS5pbzEcMBoGCSqGSIb3DQEJARYNY2FAa2V5YmFzZS5pb4IJAPzhpcIBaOeNMAwG
+A1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggIBAA3Z5FIhulYghMuHdcHYTYWc
+7xT5WD4hXQ0WALZs4p5Y+b2Af54o6v1wUE1Au97FORq5CsFXX/kGl/JzzTimeucn
+YJwGuXMpilrlHCBAL5/lSQjA7qbYIolQ3SB9ON+LYuF1jKB9k8SqNp7qzucxT3tO
+b8ZMDEPNsseC7NE2uwNtcW3yrTh6WZnSqg/jwswiWjHYDdG7U8FjMYlRol3wPux2
+PizGbSgiR+ztI2OthxtxNWMrT9XKxNQTpcxOXnLuhiSwqH8PoY17ecP8VPpaa0K6
+zym0zSkbroqydazaxcXRk3eSlc02Ktk7HzRzuqQQXhRMkxVnHbFHgGsz03L533pm
+mlIEgBMggZkHwNvs1LR7f3v2McdKulDH7Mv8yyfguuQ5Jxxt7RJhUuqSudbEhoaM
+6jAJwBkMFxsV2YnyFEd3eZ/qBYPf7TYHhyzmHW6WkSypGqSnXd4gYpJ8o7LxSf4F
+inLjxRD+H9Xn1UVXWLM0gaBB7zZcXd2zjMpRsWgezf5IR5vyakJsc7fxzgor3Qeq
+Ri6LvdEkhhFVl5rHMQBwNOPngySrq8cs/ikTLTfQVTYXXA4Ba1YyiMOlfaR1LhKw
+If1AkUV0tfCTNRZ01EotKSK77+o+k214n+BAu+7mO+9B5Kb7lMFQcuWCHXKYB2Md
+cT7Yh09F0QpFUd0ymEfv
+-----END CERTIFICATE-----`
+
+// KbwebClient is a Keybase API server client
+type KbwebClient struct {
+	http *http.Client
+}
+
+// NewKbwebClient constructs a Client
+func NewKbwebClient() (*KbwebClient, error) {
+	certPool := x509.NewCertPool()
+	ok := certPool.AppendCertsFromPEM([]byte(apiCa))
+	if !ok {
+		return nil, fmt.Errorf("Could not read CA for keybase.io")
+	}
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: certPool},
+		},
+	}
+	return &KbwebClient{http: client}, nil
+}
+
+// AnnounceNewBuild does, like, some stuff.
+func AnnounceNewBuild(buildA string, buildB string, platform string) error {
+	fmt.Printf("in announceNewBuild: %s %s %s\n", buildA, buildB, platform)
+	client, err := NewKbwebClient()
+	if err != nil {
+		return fmt.Errorf("client create failed, %s", err)
+	}
+	resp, err := client.http.Get(kbwebAPIUrl)
+	if resp != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+	if err != nil {
+		return fmt.Errorf("request failed, %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s responded with %v", kbwebAPIUrl, resp.Status)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("body err: %s", err)
+	}
+	fmt.Printf("body: %s\n", body)
+	return nil
+}

--- a/update/kbweb.go
+++ b/update/kbweb.go
@@ -60,6 +60,13 @@ type kbwebClient struct {
 	http *http.Client
 }
 
+type kbwebReply struct {
+	Status struct {
+		Code int
+		Desc string
+	}
+}
+
 // newKbwebClient constructs a Client
 func newKbwebClient() (*kbwebClient, error) {
 	certPool := x509.NewCertPool()
@@ -92,15 +99,17 @@ func (client *kbwebClient) post(keybaseToken string, path string, data []byte) e
 	if err != nil {
 		return fmt.Errorf("body err, %v", err)
 	}
-	fmt.Printf("Server reply: %s\n", body)
 
-	var reply map[string]interface{}
-	if err := json.Unmarshal(body, &reply); err != nil {
-		return fmt.Errorf("reply err, %v", err)
+	reply := &kbwebReply{}
+	if err := json.Unmarshal(body, reply); err != nil {
+		return fmt.Errorf("json reply err, %v", err)
 	}
-	num := reply["status"]["code"].(int)
-	fmt.Printf("status code was: %d\n", num)
 
+	if reply.Status.Code != 0 {
+		return fmt.Errorf("Server returned failure, %s", body)
+	}
+
+	fmt.Printf("Success.\n")
 	return nil
 }
 

--- a/update/kbweb.go
+++ b/update/kbweb.go
@@ -119,7 +119,7 @@ type announceBuildArgs struct {
 	Platform string `json:"platform"`
 }
 
-// AnnounceNewBuild tells the API server about the existence of a new build.
+// AnnounceBuild tells the API server about the existence of a new build.
 // It does not enroll it in smoke testing.
 func AnnounceBuild(keybaseToken string, buildA string, buildB string, platform string) error {
 	client, err := newKbwebClient()

--- a/update/kbweb.go
+++ b/update/kbweb.go
@@ -113,7 +113,7 @@ func (client *kbwebClient) post(keybaseToken string, path string, data []byte) e
 	return nil
 }
 
-type announceNewBuildArgs struct {
+type announceBuildArgs struct {
 	VersionA string `json:"version_a"`
 	VersionB string `json:"version_b"`
 	Platform string `json:"platform"`
@@ -121,12 +121,12 @@ type announceNewBuildArgs struct {
 
 // AnnounceNewBuild tells the API server about the existence of a new build.
 // It does not enroll it in smoke testing.
-func AnnounceNewBuild(keybaseToken string, buildA string, buildB string, platform string) error {
+func AnnounceBuild(keybaseToken string, buildA string, buildB string, platform string) error {
 	client, err := newKbwebClient()
 	if err != nil {
 		return fmt.Errorf("client create failed, %v", err)
 	}
-	args := &announceNewBuildArgs{
+	args := &announceBuildArgs{
 		VersionA: buildA,
 		VersionB: buildB,
 		Platform: platform,

--- a/update/kbweb.go
+++ b/update/kbweb.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	kbwebAPIUrl = "https://keybase.io"
+	kbwebAPIUrl = "https://api.keybase.io"
 )
 
 const apiCa = `-----BEGIN CERTIFICATE-----
@@ -76,6 +76,33 @@ func NewKbwebClient() (*KbwebClient, error) {
 	return &KbwebClient{http: client}, nil
 }
 
+func kbwebPost(path string, data []byte) error {
+	client, err := NewKbwebClient()
+	if err != nil {
+		return fmt.Errorf("client create failed, %v", err)
+	}
+
+	req, err := http.NewRequest("POST", kbwebAPIUrl+path, bytes.NewBuffer(data))
+	if err != nil {
+		return fmt.Errorf("newrequest failed, %v", err)
+	}
+	req.Header.Add("content-type", "application/json")
+	req.Header.Add("x-keybase-admin-token", "test_token")
+	resp, err := client.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed, %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("body err, %v", err)
+	}
+	fmt.Printf("body: %s\n", body)
+
+	return nil
+}
+
 type announceNewBuildArgs struct {
 	VersionA string `json:"version_a"`
 	VersionB string `json:"version_b"`
@@ -85,36 +112,17 @@ type announceNewBuildArgs struct {
 // AnnounceNewBuild tells the API server about the existence of a new build.
 // It does not enroll it in smoke testing.
 func AnnounceNewBuild(buildA string, buildB string, platform string) error {
-	client, err := NewKbwebClient()
-	if err != nil {
-		return fmt.Errorf("client create failed, %s", err)
-	}
 	args := &announceNewBuildArgs{
 		VersionA: buildA,
 		VersionB: buildB,
 		Platform: platform,
 	}
-	jsonStr, _ := json.Marshal(args)
+	jsonStr, err := json.Marshal(args)
+	if err != nil {
+		return fmt.Errorf("json marshal err, %v", err)
+	}
 	var data = []byte(jsonStr)
-	req, _ := http.NewRequest("POST", kbwebAPIUrl+"/_/api/1.0/pkg/add_build.json", bytes.NewBuffer(data))
-	req.Header.Add("content-type", "application/json")
-	req.Header.Add("x-keybase-admin-token", "test_token")
-	resp, _ := client.http.Do(req)
-	if err != nil {
-		return fmt.Errorf("request failed, %v", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("%s responded with %v", kbwebAPIUrl, resp.Status)
-	}
-	defer resp.Body.Close()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("body err: %s", err)
-	}
-	fmt.Printf("body: %s\n", body)
-
-	return nil
+	return kbwebPost("/_/api/1.0/pkg/add_build.json", data)
 }
 
 type setBuildInTestingArgs struct {
@@ -125,34 +133,15 @@ type setBuildInTestingArgs struct {
 
 // SetBuildInTesting tells the API server to enroll or unenroll a build in smoke testing.
 func SetBuildInTesting(buildA string, platform string, inTesting string) error {
-	client, err := NewKbwebClient()
-	if err != nil {
-		return fmt.Errorf("client create failed, %s", err)
-	}
 	args := &setBuildInTestingArgs{
 		VersionA:  buildA,
 		Platform:  platform,
 		InTesting: inTesting,
 	}
-	jsonStr, _ := json.Marshal(args)
+	jsonStr, err := json.Marshal(args)
+	if err != nil {
+		return fmt.Errorf("json marshal err: %v", err)
+	}
 	var data = []byte(jsonStr)
-	req, _ := http.NewRequest("POST", kbwebAPIUrl+"/_/api/1.0/pkg/set_in_testing.json", bytes.NewBuffer(data))
-	req.Header.Add("content-type", "application/json")
-	req.Header.Add("x-keybase-admin-token", "test_token")
-	resp, _ := client.http.Do(req)
-	if err != nil {
-		return fmt.Errorf("request failed, %v", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("%s responded with %v", kbwebAPIUrl, resp.Status)
-	}
-	defer resp.Body.Close()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("body err: %s", err)
-	}
-	fmt.Printf("body: %s\n", body)
-
-	return nil
+	return kbwebPost("/_/api/1.0/pkg/set_in_testing.json", data)
 }

--- a/update/kbweb.go
+++ b/update/kbweb.go
@@ -76,7 +76,7 @@ func NewKbwebClient() (*KbwebClient, error) {
 	return &KbwebClient{http: client}, nil
 }
 
-func kbwebPost(path string, data []byte) error {
+func kbwebPost(keybaseToken string, path string, data []byte) error {
 	client, err := NewKbwebClient()
 	if err != nil {
 		return fmt.Errorf("client create failed, %v", err)
@@ -87,7 +87,7 @@ func kbwebPost(path string, data []byte) error {
 		return fmt.Errorf("newrequest failed, %v", err)
 	}
 	req.Header.Add("content-type", "application/json")
-	req.Header.Add("x-keybase-admin-token", "test_token")
+	req.Header.Add("x-keybase-admin-token", keybaseToken)
 	resp, err := client.http.Do(req)
 	if err != nil {
 		return fmt.Errorf("request failed, %v", err)
@@ -111,7 +111,7 @@ type announceNewBuildArgs struct {
 
 // AnnounceNewBuild tells the API server about the existence of a new build.
 // It does not enroll it in smoke testing.
-func AnnounceNewBuild(buildA string, buildB string, platform string) error {
+func AnnounceNewBuild(keybaseToken string, buildA string, buildB string, platform string) error {
 	args := &announceNewBuildArgs{
 		VersionA: buildA,
 		VersionB: buildB,
@@ -122,7 +122,7 @@ func AnnounceNewBuild(buildA string, buildB string, platform string) error {
 		return fmt.Errorf("json marshal err, %v", err)
 	}
 	var data = []byte(jsonStr)
-	return kbwebPost("/_/api/1.0/pkg/add_build.json", data)
+	return kbwebPost(keybaseToken, "/_/api/1.0/pkg/add_build.json", data)
 }
 
 type setBuildInTestingArgs struct {
@@ -132,7 +132,7 @@ type setBuildInTestingArgs struct {
 }
 
 // SetBuildInTesting tells the API server to enroll or unenroll a build in smoke testing.
-func SetBuildInTesting(buildA string, platform string, inTesting string) error {
+func SetBuildInTesting(keybaseToken string, buildA string, platform string, inTesting string) error {
 	args := &setBuildInTestingArgs{
 		VersionA:  buildA,
 		Platform:  platform,
@@ -143,5 +143,5 @@ func SetBuildInTesting(buildA string, platform string, inTesting string) error {
 		return fmt.Errorf("json marshal err: %v", err)
 	}
 	var data = []byte(jsonStr)
-	return kbwebPost("/_/api/1.0/pkg/set_in_testing.json", data)
+	return kbwebPost(keybaseToken, "/_/api/1.0/pkg/set_in_testing.json", data)
 }

--- a/update/kbweb.go
+++ b/update/kbweb.go
@@ -56,13 +56,12 @@ If1AkUV0tfCTNRZ01EotKSK77+o+k214n+BAu+7mO+9B5Kb7lMFQcuWCHXKYB2Md
 cT7Yh09F0QpFUd0ymEfv
 -----END CERTIFICATE-----`
 
-// KbwebClient is a Keybase API server client
-type KbwebClient struct {
+type kbwebClient struct {
 	http *http.Client
 }
 
 // NewKbwebClient constructs a Client
-func NewKbwebClient() (*KbwebClient, error) {
+func newKbwebClient() (*kbwebClient, error) {
 	certPool := x509.NewCertPool()
 	ok := certPool.AppendCertsFromPEM([]byte(apiCa))
 	if !ok {
@@ -73,11 +72,11 @@ func NewKbwebClient() (*KbwebClient, error) {
 			TLSClientConfig: &tls.Config{RootCAs: certPool},
 		},
 	}
-	return &KbwebClient{http: client}, nil
+	return &kbwebClient{http: client}, nil
 }
 
 func kbwebPost(keybaseToken string, path string, data []byte) error {
-	client, err := NewKbwebClient()
+	client, err := newKbwebClient()
 	if err != nil {
 		return fmt.Errorf("client create failed, %v", err)
 	}

--- a/update/kbweb.go
+++ b/update/kbweb.go
@@ -94,6 +94,13 @@ func (client *kbwebClient) post(keybaseToken string, path string, data []byte) e
 	}
 	fmt.Printf("Server reply: %s\n", body)
 
+	var reply map[string]interface{}
+	if err := json.Unmarshal(body, &reply); err != nil {
+		return fmt.Errorf("reply err, %v", err)
+	}
+	num := reply["status"]["code"].(int)
+	fmt.Printf("status code was: %d\n", num)
+
 	return nil
 }
 


### PR DESCRIPTION
r? @gabriel, CC @oconnor663 

This PR adds two new commands:

KEYBASE_TOKEN=test_token ./release announce-new-build-to-server --build-a 1.0.0 --build-b 2.0.0 --platform darwin

KEYBASE_TOKEN=test_token ./release set-build-in-testing --build-a 1.0.0 --platform darwin --enable true

`announce-new-build-to-server` will be called at the end of every client/packaging/darwin/build_app.sh run (PR incoming) to tell the API server about the existence of a new build; `set-build-in-testing` will be called on demand via Slackbot (PR incoming) when we want to return a given build to a small sample of test users during upgrade.

The PR adds a generic client for Keybase API server POSTs.  I tested by changing the `kbwebAPIURL` to localhost.

Feel free to nitpick the code, am still inexperienced.