### PR TITLE
Add dokan product codes

### DIFF
--- a/release.go
+++ b/release.go
@@ -70,6 +70,8 @@ var (
 	updateJSONURI         = updateJSONCmd.Flag("uri", "URI for location of files").URL()
 	updateJSONSignature   = updateJSONCmd.Flag("signature", "Signature file").ExistingFile()
 	updateJSONDescription = updateJSONCmd.Flag("description", "Description file").ExistingFile()
+	updateJSONDokanCodeX86 = updateJSONCmd.Flag("DokanProductCodeX86", "DokanProductCodeX86").String()
+	updateJSONDokanCodeX64 = updateJSONCmd.Flag("DokanProductCodeX64", "DokanProductCodeX64").String()
 
 	indexHTMLCmd        = app.Command("index-html", "Generate index.html for s3 bucket")
 	indexHTMLBucketName = indexHTMLCmd.Flag("bucket-name", "Bucket name to index").Required().String()
@@ -177,7 +179,7 @@ func main() {
 			log.Fatal(err)
 		}
 	case updateJSONCmd.FullCommand():
-		out, err := update.EncodeJSON(*updateJSONVersion, tag(*updateJSONVersion), *updateJSONDescription, *updateJSONSrc, *updateJSONURI, *updateJSONSignature)
+		out, err := update.EncodeJSON(*updateJSONVersion, tag(*updateJSONVersion), *updateJSONDescription, *updateJSONSrc, *updateJSONURI, *updateJSONSignature, *updateJSONDokanCodeX64, *updateJSONDokanCodeX86)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/update/protocol.go
+++ b/update/protocol.go
@@ -35,6 +35,8 @@ type Update struct {
 	Type         Type    `codec:"type" json:"type"`
 	PublishedAt  *Time   `codec:"publishedAt,omitempty" json:"publishedAt,omitempty"`
 	Asset        *Asset  `codec:"asset,omitempty" json:"asset,omitempty"`
+	DokanCodeX86 string  `codec:"dokanCodeX86" json:"dokanCodeX86,omitempty"`
+	DokanCodeX64 string  `codec:"dokanCodeX64" json:"dokanCodeX64,omitempty"`
 }
 
 // Time as millis

--- a/update/update.go
+++ b/update/update.go
@@ -18,10 +18,12 @@ import (
 )
 
 // EncodeJSON returns JSON (as bytes) for an update
-func EncodeJSON(version string, name string, descriptionPath string, src string, URI fmt.Stringer, signaturePath string) ([]byte, error) {
+func EncodeJSON(version string, name string, descriptionPath string, src string, URI fmt.Stringer, signaturePath string, dokanCodeX64 string, dokanCodeX86 string) ([]byte, error) {
 	update := Update{
 		Version: version,
 		Name:    name,
+		DokanCodeX64: dokanCodeX64,
+		DokanCodeX86: dokanCodeX86, 
 	}
 
 	// Get published at from version string


### PR DESCRIPTION
I would like to add these codes to the updater json. I am preparing PRs for go-updater and client to match. Willing to consider a different approach or format. Again, we need the updater to be able to decide whether an update can be silent _before_ downloading it.
@max @oconnor663 @gabriel 