### PR TITLE
Hook up Windows support for releases and add a --dry-run flag

### DIFF
--- a/release.go
+++ b/release.go
@@ -91,7 +91,7 @@ var (
 	releaseToPromote          = promoteAReleaseCmd.Flag("release", "Specific release to promote to public").Required().String()
 	promoteAReleaseBucketName = promoteAReleaseCmd.Flag("bucket-name", "Bucket name to use").Required().String()
 	promoteAReleasePlatform   = promoteAReleaseCmd.Flag("platform", "Platform (darwin, linux, windows)").Required().String()
-	promoteAReleaseDryRun     = promoteAReleaseCmd.Flag("dry-run", "Announce what would be done without doing it (in-progress)").Bool()
+	promoteAReleaseDryRun     = promoteAReleaseCmd.Flag("dry-run", "Announce what would be done without doing it").Bool()
 
 	brokenReleaseCmd          = app.Command("broken-release", "Mark a release as broken")
 	brokenReleaseName         = brokenReleaseCmd.Flag("release", "Release to mark as broken").Required().String()

--- a/release.go
+++ b/release.go
@@ -212,18 +212,19 @@ func main() {
 		log.Printf("%s\n", date)
 		log.Printf("%s\n", commit)
 	case promoteReleasesCmd.FullCommand():
+		const dryRun bool = false
 		release, err := update.PromoteReleases(*promoteReleasesBucketName, *promoteReleasesPlatform)
 		if err != nil {
 			log.Fatal(err)
 		}
-		err = update.CopyLatest(*promoteReleasesBucketName, *promoteReleasesPlatform, false)
+		err = update.CopyLatest(*promoteReleasesBucketName, *promoteReleasesPlatform, dryRun)
 		if err != nil {
 			log.Fatal(err)
 		}
 		if release == nil {
 			log.Print("Not notifying API server of release")
 		} else {
-			releaseTime, err := update.KBWebPromote(keybaseToken(true), release.Version, *promoteReleasesPlatform, false)
+			releaseTime, err := update.KBWebPromote(keybaseToken(true), release.Version, *promoteReleasesPlatform, dryRun)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/update/s3.go
+++ b/update/s3.go
@@ -472,6 +472,10 @@ func PromoteARelease(releaseName string, bucketName string, platform string, dry
 	if err != nil {
 		return nil, err
 	}
+	if len(platformRes) != 1 {
+		return nil, fmt.Errorf("Promoting on multiple platforms is not supported")
+	}
+
 	platformType := platformRes[0]
 	release, err = client.promoteAReleaseToProd(releaseName, bucketName, platformType, "prod", defaultChannel, dryRun)
 	if err != nil {

--- a/update/s3.go
+++ b/update/s3.go
@@ -229,12 +229,12 @@ type Platform struct {
 }
 
 // CopyLatest copies latest release to a fixed path
-func CopyLatest(bucketName string, platform string) error {
+func CopyLatest(bucketName string, platform string, dryRun bool) error {
 	client, err := NewClient()
 	if err != nil {
 		return err
 	}
-	return client.CopyLatest(bucketName, platform)
+	return client.CopyLatest(bucketName, platform, dryRun)
 }
 
 const (
@@ -249,7 +249,7 @@ const (
 var platformDarwin = Platform{Name: PlatformTypeDarwin, Prefix: "darwin/", PrefixSupport: "darwin-support/", LatestName: "Keybase.dmg"}
 var platformLinuxDeb = Platform{Name: "deb", Prefix: "linux_binaries/deb/", Suffix: "_amd64.deb", LatestName: "keybase_amd64.deb"}
 var platformLinuxRPM = Platform{Name: "rpm", Prefix: "linux_binaries/rpm/", Suffix: ".x86_64.rpm", LatestName: "keybase_amd64.rpm"}
-var platformWindows = Platform{Name: PlatformTypeWindows, Prefix: "windows/", Suffix: ".386.exe", LatestName: "keybase_setup_386.exe"}
+var platformWindows = Platform{Name: PlatformTypeWindows, Prefix: "windows/", Suffix: ".amd64.msi", LatestName: "keybase_setup_amd64.msi"}
 
 var platformsAll = []Platform{
 	platformDarwin,
@@ -357,7 +357,7 @@ func (p Platform) WriteHTML(bucketName string) error {
 }
 
 // CopyLatest copies latest release to a fixed path for the Client
-func (c *Client) CopyLatest(bucketName string, platform string) error {
+func (c *Client) CopyLatest(bucketName string, platform string, dryRun bool) error {
 	platforms, err := Platforms(platform)
 	if err != nil {
 		return err
@@ -365,8 +365,8 @@ func (c *Client) CopyLatest(bucketName string, platform string) error {
 	for _, platform := range platforms {
 		var url string
 		// Use update json to look for current DMG (for darwin)
-		// TODO: Fix for linux, windows
-		if platform.Name == PlatformTypeDarwin {
+		// TODO: Fix for linux
+		if platform.Name == PlatformTypeDarwin || platform.Name == PlatformTypeWindows {
 			url, err = c.copyFromUpdate(platform, bucketName)
 		} else {
 			_, url, err = c.copyFromReleases(platform, bucketName)
@@ -376,6 +376,11 @@ func (c *Client) CopyLatest(bucketName string, platform string) error {
 		}
 		if url == "" {
 			continue
+		}
+
+		if dryRun {
+			log.Printf("DRYRUN: Would copy latest %s to %s\n", url, platform.LatestName)
+			return nil
 		}
 
 		_, err := c.svc.CopyObject(&s3.CopyObjectInput{
@@ -405,6 +410,8 @@ func (c *Client) copyFromUpdate(platform Platform, bucketName string) (url strin
 	switch platform.Name {
 	case PlatformTypeDarwin:
 		url = urlString(bucketName, platform.Prefix, fmt.Sprintf("Keybase-%s.dmg", currentUpdate.Version))
+	case PlatformTypeWindows:
+		url = urlString(bucketName, platform.Prefix, fmt.Sprintf("Keybase_%s.amd64.msi", currentUpdate.Version))
 	default:
 		err = fmt.Errorf("Unsupported platform for copyFromUpdate")
 	}
@@ -450,10 +457,10 @@ func updateJSONName(channel string, platformName string, env string) string {
 	return fmt.Sprintf("update-%s-%s-%s.json", platformName, env, channel)
 }
 
-// PromoteARelease promotes a specific release to Darwin Prod.
-func PromoteARelease(releaseName string, bucketName string, platform string) (release *Release, err error) {
-	if platform != PlatformTypeDarwin {
-		return nil, fmt.Errorf("Promoting releases is only supported for darwin")
+// PromoteARelease promotes a specific release to Prod.
+func PromoteARelease(releaseName string, bucketName string, platform string, dryRun bool) (release *Release, err error) {
+	if platform != PlatformTypeDarwin && platform != PlatformTypeWindows {
+		return nil, fmt.Errorf("Promoting releases is only supported for darwin or windows")
 	}
 
 	client, err := NewClient()
@@ -461,19 +468,35 @@ func PromoteARelease(releaseName string, bucketName string, platform string) (re
 		return nil, err
 	}
 
-	release, err = client.promoteDarwinReleaseToProd(releaseName, bucketName, platformDarwin, "prod", defaultChannel)
+	platformRes, err := Platforms(platform)
 	if err != nil {
 		return nil, err
 	}
-
-	log.Printf("Promoted (darwin) release: %s\n", releaseName)
+	platformType := platformRes[0]
+	release, err = client.promoteAReleaseToProd(releaseName, bucketName, platformType, "prod", defaultChannel, dryRun)
+	if err != nil {
+		return nil, err
+	}
+	if dryRun {
+		return release, nil
+	}
+	log.Printf("Promoted %s release: %s\n", platform, releaseName)
 	return release, nil
 }
 
-func (c *Client) promoteDarwinReleaseToProd(releaseName string, bucketName string, platform Platform, env string, toChannel string) (release *Release, err error) {
-	releaseName = fmt.Sprintf("Keybase-%s.dmg", releaseName)
+func (c *Client) promoteAReleaseToProd(releaseName string, bucketName string, platform Platform, env string, toChannel string, dryRun bool) (release *Release, err error) {
+	var filePath string
+	switch platform.Name {
+	case PlatformTypeDarwin:
+		filePath = fmt.Sprintf("Keybase-%s.dmg", releaseName)
+	case PlatformTypeWindows:
+		filePath = fmt.Sprintf("Keybase_%s.amd64.msi", releaseName)
+	default:
+		return nil, fmt.Errorf("Unsupported for this platform: %s", platform.Name)
+	}
+
 	release, err = platform.FindRelease(bucketName, func(r Release) bool {
-		return r.Name == releaseName
+		return r.Name == filePath
 	})
 	if err != nil {
 		return nil, err
@@ -481,11 +504,15 @@ func (c *Client) promoteDarwinReleaseToProd(releaseName string, bucketName strin
 	if release == nil {
 		return nil, fmt.Errorf("No matching release found")
 	}
-	log.Printf("Found release %s (%s), %s", release.Name, time.Since(release.Date), release.Version)
+	log.Printf("Found %s release %s (%s), %s", platform.Name, release.Name, time.Since(release.Date), release.Version)
 	jsonName := updateJSONName(toChannel, platform.Name, env)
 	jsonURL := urlString(bucketName, platform.PrefixSupport, fmt.Sprintf("update-%s-%s-%s.json", platform.Name, env, release.Version))
-	log.Printf("PutCopying %s to %s\n", jsonURL, jsonName)
 
+	if dryRun {
+		log.Printf("DRYRUN: Would PutCopy %s to %s\n", jsonURL, jsonName)
+		return release, nil
+	}
+	log.Printf("PutCopying %s to %s\n", jsonURL, jsonName)
 	_, err = c.svc.CopyObject(&s3.CopyObjectInput{
 		Bucket:       aws.String(bucketName),
 		CopySource:   aws.String(jsonURL),


### PR DESCRIPTION
r? @mlsteele CC @keybase/picnicsquad 

Here's the release script side of Windows support.  I also added a --dry-run flag for debugging.  I don't write Go very often so idiomatic suggestions are super welcome.

Output:

Windows:
```
 λ ./release promote-a-release --dry-run --release 4.4.1-20190909144547+b5f8897c2a --bucket-name prerelease.keybase.io --platform windows
2019/09/10 00:06:26 Response is truncated, next marker is windows/Keybase_2.6.0-20180829161023+d4004d71c4.386.msi
2019/09/10 00:06:26 Found windows release Keybase_4.4.1-20190909144547+b5f8897c2a.amd64.msi (16h20m39.582132775s), 4.4.1-20190909144547+b5f8897c2a
2019/09/10 00:06:26 DRYRUN: Would PutCopy https://s3.amazonaws.com/prerelease.keybase.io/update-windows-prod-4.4.1-20190909144547%2Bb5f8897c2a.json to update-windows-prod-v2.json
2019/09/10 00:06:26 DRYRUN: Would copy latest https://s3.amazonaws.com/prerelease.keybase.io/windows/Keybase_4.4.1-20190909144547%2Bb5f8897c2a.amd64.msi to keybase_setup_amd64.msi
2019/09/10 00:06:26 DRYRUN: Would post {"version_a":"4.4.1-20190909144547+b5f8897c2a","platform":"windows"}
```

macOS:
```
 λ ./release promote-a-release --dry-run --release 4.4.1-20190909184517+b5f8897c2a --bucket-name prerelease.keybase.io --platform darwin 
2019/09/10 00:06:48 Response is truncated, next marker is darwin/Keybase-1.0.48-20180516161253+b56432f520.dmg
2019/09/10 00:06:49 Response is truncated, next marker is darwin/Keybase-3.1.0-20190301194112+10a818cee8.dmg
2019/09/10 00:06:49 Found darwin release Keybase-4.4.1-20190909184517+b5f8897c2a.dmg (12h21m32.470343746s), 4.4.1-20190909184517+b5f8897c2a
2019/09/10 00:06:49 DRYRUN: Would PutCopy https://s3.amazonaws.com/prerelease.keybase.io/darwin-support/update-darwin-prod-4.4.1-20190909184517%2Bb5f8897c2a.json to update-darwin-prod-v2.json
2019/09/10 00:06:49 DRYRUN: Would copy latest https://s3.amazonaws.com/prerelease.keybase.io/darwin/Keybase-4.4.1-20190909184517%2Bb5f8897c2a.dmg to Keybase.dmg
2019/09/10 00:06:49 DRYRUN: Would post {"version_a":"4.4.1-20190909184517+b5f8897c2a","platform":"darwin"}
```